### PR TITLE
deploy/helm: correctly format image hash as tag

### DIFF
--- a/deploy/helm/wildwest-controller/templates/_helpers.tpl
+++ b/deploy/helm/wildwest-controller/templates/_helpers.tpl
@@ -49,6 +49,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the container image reference, handling both tag and digest formats.
+*/}}
+{{- define "wildwest-controller.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if hasPrefix "@" $tag -}}
+{{- printf "%s%s" .Values.image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "wildwest-controller.serviceAccountName" -}}

--- a/deploy/helm/wildwest-controller/templates/deployment.yaml
+++ b/deploy/helm/wildwest-controller/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "wildwest-controller.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpointslice={{ .Values.controller.endpointSlice }}

--- a/deploy/helm/wildwest-portal/templates/_helpers.tpl
+++ b/deploy/helm/wildwest-portal/templates/_helpers.tpl
@@ -49,6 +49,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the container image reference, handling both tag and digest formats.
+*/}}
+{{- define "wildwest-portal.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if hasPrefix "@" $tag -}}
+{{- printf "%s%s" .Values.image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "wildwest-portal.serviceAccountName" -}}

--- a/deploy/helm/wildwest-portal/templates/deployment.yaml
+++ b/deploy/helm/wildwest-portal/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "wildwest-portal.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
This PR adds wildwest-controller.image helper to format image URL.