### PR TITLE
fix(ci): grant packages: write to publish-ocm job

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -114,6 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-controller, build-portal]
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
The publish-ocm job had no permissions: block, so GITHUB_TOKEN defaulted to the repo/org baseline (read-only in most setups). All the per-package allow-listing in GHCR was wasted because the token itself never had write scope. Mirror the permissions: block from build-controller / build-portal.