### PR TITLE
fix(ocm): declare source repo so GHCR auto-links packages

### DIFF
--- a/constructor/component-constructor.yaml
+++ b/constructor/component-constructor.yaml
@@ -3,17 +3,6 @@ components:
     version: {{ .VERSION }}
     provider:
       name: platform-mesh
-    labels:
-      - name: org.opencontainers.image.source
-        value: https://github.com/platform-mesh/provider-quickstart
-    sources:
-      - name: source
-        type: git
-        version: {{ .VERSION }}
-        access:
-          type: gitHub
-          repoUrl: https://github.com/platform-mesh/provider-quickstart
-          ref: refs/heads/main
     resources:
       - name: controller-chart
         type: helmChart


### PR DESCRIPTION
Helm charts and the OCM component-descriptor are pushed to GHCR as OCI artifacts. Without an org.opencontainers.image.source annotation on the manifest, GHCR has no way to link the resulting org package back to the provider-quickstart repo, which leaves the package dangling and blocks the workflow's GITHUB_TOKEN from writing subsequent versions.

- Add sources: to both Chart.yaml files; Helm propagates sources[0] as org.opencontainers.image.source on the chart manifest.
- Add a labels: block on the OCM component so the same annotation lands on the component-descriptor manifest.

Existing dangling packages will need to be deleted and re-pushed once for the annotation to apply; after that CI can write.