### PR TITLE
ci: publish Wild West Helm charts as OCI artifacts

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -163,3 +163,34 @@ jobs:
             CHART_VERSION=${{ steps.version.outputs.version }} \
             IMAGE_VERSION=${{ steps.version.outputs.version }} \
             OCI_TAG=${{ steps.version.outputs.version }}
+
+  publish-helm:
+    runs-on: ubuntu-latest
+    needs: [build-controller, build-portal]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          REF_NAME="${GITHUB_REF_NAME}"
+          VERSION="${REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Package and push Helm charts
+        run: |
+          make helm-push \
+            CHART_VERSION=${{ steps.version.outputs.version }} \
+            IMAGE_VERSION=${{ steps.version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,16 @@ OCM_CTF ?= .ocm/transport.ctf
 VERSION ?= 0.0.0-dev
 CHART_VERSION ?= $(VERSION)
 IMAGE_VERSION ?= $(VERSION)
+
+# Helm chart publishing parameters
+HELM ?= helm
+# Charts are published under this repo's own GHCR namespace (self-contained,
+# alongside the container images) rather than the shared helm-charts registry.
+HELM_REPO ?= ghcr.io/platform-mesh/provider-quickstart/charts
+# Deployable charts published as standalone OCI Helm artifacts. These are consumed
+# by the platform-mesh-operator ManagedProvider machinery (Flux OCIRepository ->
+# HelmRelease); see config/pm/README.md.
+HELM_CHARTS ?= wildwest-controller wildwest-portal wildwest-armament-sync
 # OCI registry tag for the referenced images (free-form, e.g. "latest" or "0.1.0").
 # Defaults to "latest" so local builds resolve against an existing tag; CI sets it to the release tag.
 OCI_TAG ?= latest
@@ -247,6 +257,21 @@ ocm-push: ocm-build
 .PHONY: ocm-describe
 ocm-describe: ocm-build
 	$(OCM) get componentversions --repo $(OCM_CTF) -o yaml
+
+## helm-push: Package and push deployable Helm charts to $(HELM_REPO) as OCI artifacts
+.PHONY: helm-push
+helm-push:
+	mkdir -p $(BUILD_DIR)/charts
+	@for chart in $(HELM_CHARTS); do \
+	  echo "==> packaging $$chart $(CHART_VERSION)"; \
+	  $(HELM) dependency build deploy/helm/$$chart || exit 1; \
+	  $(HELM) package deploy/helm/$$chart \
+	    --version $(CHART_VERSION) \
+	    --app-version $(IMAGE_VERSION) \
+	    --destination $(BUILD_DIR)/charts || exit 1; \
+	  echo "==> pushing $$chart-$(CHART_VERSION).tgz to oci://$(HELM_REPO)"; \
+	  $(HELM) push $(BUILD_DIR)/charts/$$chart-$(CHART_VERSION).tgz oci://$(HELM_REPO) || exit 1; \
+	done
 
 ## help: Display this help
 .PHONY: help

--- a/config/pm/README.md
+++ b/config/pm/README.md
@@ -1,0 +1,98 @@
+# Bootstrapping the quickstart provider with `ManagedProvider`
+
+This directory contains a declarative way to bootstrap the quickstart ("Wild West")
+provider using the [platform-mesh-operator](https://github.com/platform-mesh/platform-mesh-operator)
+`ManagedProvider` machinery — instead of the manual `make init` + local controller
+flow documented in the top-level [README](../../README.md).
+
+You apply **one** resource ([`managedprovider.yaml`](./managedprovider.yaml)) to the
+runtime cluster and the operator drives the entire lifecycle.
+
+## What `ManagedProvider` does
+
+`ManagedProvider` is a namespaced CRD
+(`providers.platform-mesh.io/v1alpha1`) reconciled by the operator through a chain of
+subroutines:
+
+| # | Subroutine        | Effect |
+|---|-------------------|--------|
+| 1 | `WaitPlatformMesh`| Waits for the referenced `PlatformMesh` to be `Ready`. |
+| 2 | `ProviderResource`| Creates a kcp `Provider` (default path `root:providers:system`). The Provider controller provisions a dedicated provider **workspace** + a scoped admin kubeconfig `Secret`. |
+| 3 | `WaitProvider`    | Waits for the `Provider` to reach `phase=Ready`. |
+| 4 | `KubeconfigCopy`  | Copies that kubeconfig into the runtime namespace as `Secret/wildwest-provider-kubeconfig` (key `kubeconfig`). |
+| 5 | `Deploy`          | For each `runtimeDeployments[].ocm` entry, creates a Flux `OCIRepository` (`oci://<registry>/<componentName>:<version>`, helm-chart layer) + a `HelmRelease` that installs the chart into the runtime namespace. |
+
+The provider workspace created in step 2 is **empty**. The `wildwest-controller`
+chart's **init container** (`init.enabled: true`) bootstraps the workspace content —
+the Cowboys `APIResourceSchema`/`APIExport`, the Armaments CRD and the
+`ProviderMetadata` — using the copied provider kubeconfig, before the controller's main
+container begins reconciling.
+
+## Prerequisites
+
+On the **runtime cluster**:
+
+- The **platform-mesh-operator** is installed and running (it owns the
+  `ManagedProvider`/`Provider` CRDs and reconcilers).
+- **FluxCD** source-controller + helm-controller are installed (the operator emits
+  `OCIRepository` / `HelmRelease` objects — GVKs `source.toolkit.fluxcd.io/v1` and
+  `helm.toolkit.fluxcd.io/v2`).
+- A **`PlatformMesh`** object named `platform-mesh` exists and is `Ready` (adjust
+  `spec.platformMeshRef.name` if yours differs).
+- The `platform-mesh-system` namespace exists.
+
+Published artifacts the manifest references:
+
+- OCI **Helm charts** at (version tracks the release tag — latest is `v0.0.6`):
+  - `oci://ghcr.io/platform-mesh/provider-quickstart/charts/wildwest-controller:0.0.6`
+  - `oci://ghcr.io/platform-mesh/provider-quickstart/charts/wildwest-portal:0.0.6`
+- The chart `values.image.tag` digests resolve from `ghcr.io/platform-mesh/provider-quickstart*`.
+
+> **Publishing note.** The operator's `Deploy` subroutine consumes **plain OCI Helm
+> chart artifacts** (Flux `OCIRepository` with the helm-chart layer selector), *not* the
+> bundled OCM component descriptor. The charts under [`deploy/helm/`](../../deploy/helm/)
+> are published as standalone OCI Helm charts under this repo's own GHCR namespace
+> (`ghcr.io/platform-mesh/provider-quickstart/charts`, alongside the container images) by
+> the `publish-helm` job in [`build-images.yaml`](../../.github/workflows/build-images.yaml)
+> on every `v*` tag (via `make helm-push`). CI versions all release artifacts from the git
+> tag (`VERSION = ${tag#v}`), so the chart version equals the release tag — latest is
+> `v0.0.6`. (The internal `deploy/helm/*/Chart.yaml` version is overridden at publish
+> time.) If you publish elsewhere, update `registry` / `componentName` / `version` in
+> [`managedprovider.yaml`](./managedprovider.yaml) accordingly.
+
+## Apply
+
+```bash
+# kube context / KUBECONFIG must point at the runtime cluster running the operator
+kubectl apply -k config/pm
+```
+
+## Observe
+
+```bash
+# Lifecycle phase: Pending -> WaitingForPlatformMesh -> WaitingForProvider
+#                  -> CopyingKubeconfig -> Deploying -> Ready
+kubectl get managedprovider wildwest -n platform-mesh-system -w
+
+# The Provider created in kcp
+kubectl get provider -A
+
+# Copied provider kubeconfig
+kubectl get secret wildwest-provider-kubeconfig -n platform-mesh-system
+
+# Flux objects emitted by the Deploy subroutine
+kubectl get ocirepository,helmrelease -n platform-mesh-system
+
+# Workloads
+kubectl get pods -n platform-mesh-system -l app.kubernetes.io/name=wildwest-controller
+```
+
+## Tear down
+
+```bash
+kubectl delete -k config/pm
+```
+
+Set `spec.cleanupOnDelete: true` in [`managedprovider.yaml`](./managedprovider.yaml)
+to also remove the kcp provider workspace on deletion. The `Deploy` finalizer removes
+the `HelmRelease`/`OCIRepository` objects (and thus the deployed charts) regardless.

--- a/config/pm/kustomization.yaml
+++ b/config/pm/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Apply against the runtime cluster where the platform-mesh-operator runs:
+#   kubectl apply -k config/pm
+namespace: platform-mesh-system
+resources:
+  - managedprovider.yaml

--- a/config/pm/managedprovider.yaml
+++ b/config/pm/managedprovider.yaml
@@ -1,0 +1,93 @@
+# ManagedProvider drives the platform-mesh-operator to bootstrap the quickstart
+# ("Wild West") provider end-to-end:
+#
+#   1. WaitPlatformMesh   - waits for the referenced PlatformMesh to be Ready.
+#   2. ProviderResource   - creates a Provider in kcp (default: root:providers:system),
+#                           which provisions a dedicated provider workspace + a scoped
+#                           admin kubeconfig Secret inside that workspace.
+#   3. WaitProvider       - waits for the Provider to reach phase=Ready.
+#   4. KubeconfigCopy     - copies that kubeconfig into this runtime namespace as
+#                           Secret "<name>-provider-kubeconfig" (key: kubeconfig).
+#   5. Deploy             - for every runtimeDeployments[].ocm entry it creates a Flux
+#                           OCIRepository (oci://<registry>/<componentName>:<version>,
+#                           helm-chart layer) + a HelmRelease that installs the chart
+#                           into this namespace.
+#
+# The wildwest-controller chart consumes the copied provider kubeconfig: its init
+# container (init.enabled=true) bootstraps the provider workspace content (Cowboys
+# APIResourceSchema/APIExport, Armaments CRD, ProviderMetadata, content config) and
+# the main container then reconciles Cowboys against that workspace.
+apiVersion: providers.platform-mesh.io/v1alpha1
+kind: ManagedProvider
+metadata:
+  name: wildwest
+  namespace: platform-mesh-system
+spec:
+  # The PlatformMesh this provider is onboarded onto. Must exist and be Ready.
+  platformMeshRef:
+    name: platform-mesh
+
+  # Remove the kcp provider workspace when this ManagedProvider is deleted.
+  cleanupOnDelete: false
+
+  # Components installed into the runtime cluster. Each entry points Flux at an
+  # OCI Helm chart artifact: oci://<registry>/<componentName>:<version>.
+  runtimeDeployments:
+    # ---- Wild West controller -------------------------------------------------
+    - ocm:
+        componentName: wildwest-controller
+        registry: ghcr.io/platform-mesh/provider-quickstart/charts
+        version: "0.0.6"
+        values:
+          # Provider-workspace kubeconfig copied in by the operator
+          # (defaults to <ManagedProvider.name>-provider-kubeconfig / key "kubeconfig").
+          kubeconfig:
+            secretName: wildwest-provider-kubeconfig
+            secretKey: kubeconfig
+          controller:
+            endpointSlice: wildwest.platform-mesh.io
+          # Bootstrap the provider workspace content before the controller starts.
+          # The Provider machinery creates an EMPTY workspace; this init container
+          # installs the Cowboys APIExport/schema, Armaments CRD and ProviderMetadata.
+          init:
+            enabled: true
+            kubeconfig:
+              secretName: wildwest-provider-kubeconfig
+              secretKey: kubeconfig
+            # We bootstrap into the existing provider workspace, so do NOT seed the
+            # workspace hierarchy.
+            seedWorkspaces: false
+            # If the copied kubeconfig needs a different front-proxy host than the one
+            # baked in, set providerHostOverride on this spec (preferred) or:
+            # hostOverride: https://frontproxy-front-proxy.platform-mesh-system:8443
+
+    # ---- Wild West portal (Angular UI) ---------------------------------------
+    - ocm:
+        componentName: wildwest-portal
+        registry: ghcr.io/platform-mesh/provider-quickstart/charts
+        version: "0.0.6"
+        # Portal needs no kubeconfig. Enable httpRoute/middleware here if your
+        # runtime exposes a Gateway (see deploy/helm/wildwest-portal/values.yaml).
+        # values:
+        #   httpRoute:
+        #     enabled: true
+        #   middleware:
+        #     enabled: true
+
+  # ---- Optional overrides -----------------------------------------------------
+  # Override the kcp front-proxy host written into the generated kubeconfig:
+  # providerHostOverride: https://frontproxy-front-proxy.platform-mesh-system:8443
+  #
+  # Store the copied kubeconfig under a custom Secret name/key (default shown):
+  # providerKubeconfigSecret:
+  #   name: wildwest-provider-kubeconfig
+  #   key: kubeconfig
+  #
+  # Deploy the Helm charts into a different runtime cluster (Secret with key
+  # "kubeconfig" in this namespace); omit to use the hosting cluster:
+  # runtimeKubeconfigSecretName: platform-runtime-kubeconfig
+  #
+  # Create/adopt the Provider in a specific workspace instead of root:providers:system:
+  # provider:
+  #   path: root:orgs:org-a:demo-acc
+  #   name: wildwest


### PR DESCRIPTION
## Why

The [platform-mesh-operator](https://github.com/platform-mesh/platform-mesh-operator) `ManagedProvider` machinery deploys provider components by emitting a Flux `OCIRepository` → `HelmRelease` pointing at `oci://<registry>/<componentName>:<version>` and selecting the Helm chart layer. It **cannot** resolve charts out of the bundled OCM component descriptor.

Today this repo only publishes the container images and the OCM component — the `wildwest-*` charts are not available as standalone OCI Helm chart artifacts, so a `ManagedProvider` referencing this provider has nothing to pull. (Confirmed: the operator's own e2e test deploys a real standalone chart, `example-httpbin-operator`.)
